### PR TITLE
Update base images for 94.6

### DIFF
--- a/dockerfile/rh-ubi/Dockerfile
+++ b/dockerfile/rh-ubi/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.23-3.1756174627
+FROM registry.access.redhat.com/ubi8/openjdk-17:1.23-3.1759823914
 
 ARG VERSION
 ARG RELEASE


### PR DESCRIPTION
## Summary

- Updated Red Hat UBI8 OpenJDK-17 base image from `1.23-3.1756174627` to [`1.23-3.1759823914`](https://catalog.redhat.com/en/software/containers/ubi8/openjdk-17/618bdbf34ae3739687568813)
- Latest October 2025 build (built 2025-10-07)
- Maintains same OpenJDK 17 version 1.23

## Test plan

- [ ] Build the `rh-ubi` Docker image variant to verify it builds successfully
- [ ] Verify the image runs and starts Kpow correctly
- [ ] Check that the OpenJDK version is still 17.0.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Other base images

```text
 Base Image Version Status

  1. Amazon Corretto (Used in 5 Dockerfiles)

  - Current in Dockerfiles: amazoncorretto:17.0.16
  - Latest available: amazoncorretto:17 → 17.0.16+8
  - Status: ✅ Already up to date (same JDK version)

  2. Eclipse Temurin UBI9 (Used in temurin-ubi/Dockerfile)

  - Current in Dockerfile: eclipse-temurin:17.0.16_8-jre-ubi9-minimal
  - Latest available: eclipse-temurin:17-jre-ubi9-minimal → 17.0.16+8
  - Status: ✅ Already up to date (same JDK version)

  3. Red Hat UBI8 OpenJDK-17 (Used in rh-ubi/Dockerfile)

  - Current in Dockerfile: registry.access.redhat.com/ubi8/openjdk-17:1.23-3.1756174627
  - Latest available: registry.access.redhat.com/ubi8/openjdk-17:1.23-3.1759823914
  - Status: 🔄 UPDATE AVAILABLE
    - Build date: 2025-10-07
    - Same version (1.23) but newer release tag
 ```
