### PR TITLE
Enable Dependabot for Docker base image updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/dockerfile"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
Configure Dependabot to automatically monitor and update Docker base images.

## Changes
- Add `.github/dependabot.yml` configuration
- Monitors all Dockerfiles in `dockerfile/` directory
- Runs weekly checks for base image updates

## How It Works
Dependabot will:
- Check for new versions of Docker base images (Amazon Corretto, Red Hat UBI, Eclipse Temurin)
- Automatically create PRs when updates are available
- Run checks every week

## Test Plan
- [x] Configuration file syntax validated
- [ ] Wait for Dependabot to run and verify PRs are created
- [ ] Review and test generated PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)