### PR TITLE
Fix Dependabot config to list subdirectories explicitly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,13 @@
 version: 2
 updates:
   - package-ecosystem: "docker"
-    directory: "/dockerfile"
+    directories:
+      - "/dockerfile/aws-mkt-lm"
+      - "/dockerfile/aws-mkt-pro"
+      - "/dockerfile/compat"
+      - "/dockerfile/kpow-ce"
+      - "/dockerfile/kpow"
+      - "/dockerfile/rh-ubi"
+      - "/dockerfile/temurin-ubi"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Problem

The initial Dependabot configuration failed with:

> Dependabot couldn't find a Dockerfile
> 
> Dependabot requires a Dockerfile to evaluate your Docker dependencies. It had expected to find one at the path: /dockerfile/Dockerfile.

## Solution

Dependabot doesn't search subdirectories recursively, so we need to explicitly list each subdirectory containing a Dockerfile using the `directories` configuration option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)