### PR TITLE
Add guard to prevent -rc versions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,10 @@ jobs:
         run: |
           ./scripts/release_number_check.sh ${{github.event.inputs.release_number_bump}}
 
+      - name: Check version does not contain -rc
+        run: |
+          ./scripts/release_version_check.sh ${{github.event.inputs.version}}
+
       - name: Configure AWS Credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/scripts/release_version_check.sh
+++ b/scripts/release_version_check.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -Eeuxo pipefail
+
+VERSION=$1
+
+if [[ "$VERSION" == *"-rc"* ]]; then
+  echo "Error: Release version cannot contain '-rc'. Use the release_rc workflow for RC releases."
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
See https://factorhouse.slack.com/archives/C09TR33DWE9/p1764805960194899?thread_ts=1764805852.961479&cid=C09TR33DWE9

This is the _Release Kpow_ run against an RC version number failing almost at the end: https://github.com/factorhouse/kpow/actions/runs/19912261860/job/57083395116

```
✓ 11:04 % ./scripts/release_version_check.sh 95.2
+ VERSION=95.2
+ [[ 95.2 == *\-\r\c* ]]
+ exit 0
✓ 11:15 % ./scripts/release_version_check.sh 95.2-rc1
+ VERSION=95.2-rc1
+ [[ 95.2-rc1 == *\-\r\c* ]]
+ echo 'Error: Release version cannot contain '\''-rc'\''. Use the release_rc workflow for RC releases.'
Error: Release version cannot contain '-rc'. Use the release_rc workflow for RC releases.
+ exit 1
✗ 11:15 %
```

## Summary
- Add validation check to Release Kpow workflow that fails if version contains `-rc`
- Create `scripts/release_version_check.sh` to validate version format
- Check runs early in workflow before AWS credentials setup
- Provides clear error message directing users to `release_rc` workflow

## Test plan
- Verify the script correctly rejects versions containing `-rc`
- Verify the script accepts versions without `-rc`
- Confirm workflow fails early when `-rc` version is provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)