### PR TITLE
use matrix to docker build in parallel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,14 @@ jobs:
             image_tag: ${{github.event.inputs.version}}-compat
             dockerfile: dockerfile/compat/Dockerfile
             script: build_all.sh
+          - image_id: factorhouse/kpow-ce
+            image_tag: ${{github.event.inputs.version}}
+            dockerfile: dockerfile/kpow-ce/Dockerfile
+            script: build_all.sh
+          - image_id: factorhouse/kpow-ce
+            image_tag: latest
+            dockerfile: dockerfile/kpow-ce/Dockerfile
+            script: build_all.sh
     steps:
       - uses: actions/checkout@v4
 
@@ -185,38 +193,8 @@ jobs:
           IMAGE_TAG=${{ matrix.image_tag }}
           ./scripts/${{ matrix.script }} $VERSION $IMAGE_ID $IMAGE_TAG ${{ matrix.dockerfile }}
 
-  build-docker-ce:
-    needs: setup
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Download JARs
-        uses: actions/download-artifact@v4
-        with:
-          name: kpow-jars
-          path: target/
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build Kpow Community
-        run: |
-          NEXT_RELEASE=${{github.event.inputs.version}}
-          docker buildx build -f ./dockerfile/kpow-ce/Dockerfile --platform=linux/amd64,linux/arm64 --sbom=true --provenance=true -t factorhouse/kpow-ce:latest --push .
-          docker buildx build -f ./dockerfile/kpow-ce/Dockerfile --platform=linux/amd64,linux/arm64 --sbom=true --provenance=true -t factorhouse/kpow-ce:$NEXT_RELEASE --push .
-
   finalize:
-    needs: [release-jars-and-artifacts, build-docker, build-docker-ce]
+    needs: [release-jars-and-artifacts, build-docker]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Feel free to reject as this is a bit out of scope, but I saw an easy opportunity to reduce build time by more than half. I'm hoping this change will bring the exec time down to 5-6 minutes.

The crux of the build time is building the docker images and what I've implemented puts the build args into a matrix in the `build-docker` step so each entry runs simultaneously (or at least as fast as we get assigned workers from GH actions).

Changes
- Split the "build" step into `setup`, `release-jars-and-artifacts`, `build-docker`, `build-docker-ce`, `finalize` to cover each phase of the release
- Use upload artifacts to persist JARs (and dep checker reports) between steps