### PR TITLE
Add newest `JVM_OPTS` flags from 3c1705d to all Java 25-based images

### DIFF
--- a/dockerfile/aws-mkt-lm/Dockerfile
+++ b/dockerfile/aws-mkt-lm/Dockerfile
@@ -29,6 +29,6 @@ RUN yum remove shadow-utils -y
 
 USER factorhouse
 
-ENV JVM_OPTS="-server -Dorg.xerial.snappy.tempdir=/opt/factorhouse/tmp -XX:MaxInlineLevel=15 -Djava.awt.headless=true -XX:InitialRAMPercentage=70 -XX:MaxRAMPercentage=70"
+ENV JVM_OPTS="-server -Dorg.xerial.snappy.tempdir=/opt/factorhouse/tmp -XX:MaxInlineLevel=15 -Djava.awt.headless=true -XX:InitialRAMPercentage=70 -XX:MaxRAMPercentage=70 --sun-misc-unsafe-memory-access=allow -XX:+UseCompactObjectHeaders -XX:+UseStringDeduplication"
 
 CMD ["/usr/local/bin/kpow.sh"]

--- a/dockerfile/aws-mkt-pro/Dockerfile
+++ b/dockerfile/aws-mkt-pro/Dockerfile
@@ -29,6 +29,6 @@ RUN yum remove shadow-utils -y
 
 USER factorhouse
 
-ENV JVM_OPTS="-server -Dorg.xerial.snappy.tempdir=/opt/factorhouse/tmp -XX:MaxInlineLevel=15 -Djava.awt.headless=true -XX:InitialRAMPercentage=70 -XX:MaxRAMPercentage=70"
+ENV JVM_OPTS="-server -Dorg.xerial.snappy.tempdir=/opt/factorhouse/tmp -XX:MaxInlineLevel=15 -Djava.awt.headless=true -XX:InitialRAMPercentage=70 -XX:MaxRAMPercentage=70 --sun-misc-unsafe-memory-access=allow -XX:+UseCompactObjectHeaders -XX:+UseStringDeduplication"
 
 CMD ["/usr/local/bin/kpow.sh"]

--- a/dockerfile/kpow-ce/Dockerfile
+++ b/dockerfile/kpow-ce/Dockerfile
@@ -32,6 +32,6 @@ RUN yum remove shadow-utils -y
 USER factorhouse
 
 ENV CONFIG_DIR=/opt/factorhouse/config/kpow
-ENV JVM_OPTS="-server -Dorg.xerial.snappy.tempdir=/opt/factorhouse/tmp -XX:MaxInlineLevel=15 -Djava.awt.headless=true -XX:InitialRAMPercentage=70 -XX:MaxRAMPercentage=70"
+ENV JVM_OPTS="-server -Dorg.xerial.snappy.tempdir=/opt/factorhouse/tmp -XX:MaxInlineLevel=15 -Djava.awt.headless=true -XX:InitialRAMPercentage=70 -XX:MaxRAMPercentage=70 --sun-misc-unsafe-memory-access=allow -XX:+UseCompactObjectHeaders -XX:+UseStringDeduplication"
 
 CMD ["/usr/local/bin/kpow.sh"]

--- a/dockerfile/rh-ubi/Dockerfile
+++ b/dockerfile/rh-ubi/Dockerfile
@@ -26,5 +26,5 @@ RUN chown -R factorhouse:factorhouse /opt/factorhouse
 EXPOSE 3000
 USER factorhouse
 
-ENV JVM_OPTS="-server -Dorg.xerial.snappy.tempdir=/opt/factorhouse/tmp -XX:MaxInlineLevel=15 -Djava.awt.headless=true -XX:InitialRAMPercentage=70 -XX:MaxRAMPercentage=70"
+ENV JVM_OPTS="-server -Dorg.xerial.snappy.tempdir=/opt/factorhouse/tmp -XX:MaxInlineLevel=15 -Djava.awt.headless=true -XX:InitialRAMPercentage=70 -XX:MaxRAMPercentage=70 --sun-misc-unsafe-memory-access=allow -XX:+UseCompactObjectHeaders -XX:+UseStringDeduplication"
 CMD ["/usr/local/bin/kpow.sh"]

--- a/dockerfile/strimzi/Dockerfile
+++ b/dockerfile/strimzi/Dockerfile
@@ -29,6 +29,6 @@ RUN yum remove shadow-utils -y
 
 USER factorhouse
 
-ENV JVM_OPTS="-server -Dorg.xerial.snappy.tempdir=/opt/factorhouse/tmp -XX:MaxInlineLevel=15 -Djava.awt.headless=true -XX:InitialRAMPercentage=70 -XX:MaxRAMPercentage=70"
+ENV JVM_OPTS="-server -Dorg.xerial.snappy.tempdir=/opt/factorhouse/tmp -XX:MaxInlineLevel=15 -Djava.awt.headless=true -XX:InitialRAMPercentage=70 -XX:MaxRAMPercentage=70 --sun-misc-unsafe-memory-access=allow -XX:+UseCompactObjectHeaders -XX:+UseStringDeduplication"
 
 CMD ["/usr/local/bin/kpow.sh"]

--- a/dockerfile/temurin-ubi/Dockerfile
+++ b/dockerfile/temurin-ubi/Dockerfile
@@ -24,5 +24,5 @@ RUN chown -R factorhouse:factorhouse /opt/factorhouse
 EXPOSE 3000
 USER factorhouse
 
-ENV JVM_OPTS="-server -Dorg.xerial.snappy.tempdir=/opt/factorhouse/tmp -XX:MaxInlineLevel=15 -Djava.awt.headless=true -XX:InitialRAMPercentage=70 -XX:MaxRAMPercentage=70"
+ENV JVM_OPTS="-server -Dorg.xerial.snappy.tempdir=/opt/factorhouse/tmp -XX:MaxInlineLevel=15 -Djava.awt.headless=true -XX:InitialRAMPercentage=70 -XX:MaxRAMPercentage=70 --sun-misc-unsafe-memory-access=allow -XX:+UseCompactObjectHeaders -XX:+UseStringDeduplication"
 CMD ["/usr/local/bin/kpow.sh"]


### PR DESCRIPTION
See https://github.com/factorhouse/kpow/commit/3c1705dd33e12fbb64ffb852ca763088b63b954b

### Notes for reviewers

Ensure only Java 25-based Dockerfiles have the new flags